### PR TITLE
Use aiohttp to make parallel calls to the csw

### DIFF
--- a/xcube_cmems/cmems.py
+++ b/xcube_cmems/cmems.py
@@ -42,7 +42,16 @@ CSW_NAMESPACES = {
     'dc': 'http://purl.org/dc/elements/1.1/',
     'csw': 'http://www.opengis.net/cat/csw/2.0.2'
 }
+
 _RECORDS_PER_REQUEST = 25
+_GET_RECORDS_REQUEST = {
+    'service': 'CSW',
+    'request': 'GetRecords',
+    'version': '2.0.2',
+    'resultType': 'results',
+    'ElementSetName': 'full',
+    'maxRecords': _RECORDS_PER_REQUEST
+}
 # Ideally, we would read this from cmems
 _TOTAL_NUM_OF_RECORDS = 300
 
@@ -128,15 +137,7 @@ class Cmems:
 
     async def read_data_ids_from_csw_records(self, start_record: int,
                                              session: aiohttp.ClientSession):
-        params = {
-            'service': 'CSW',
-            'request': 'GetRecords',
-            'version': '2.0.2',
-            'resultType': 'results',
-            'ElementSetName': 'full',
-            'startPosition': start_record + 1,
-            'maxRecords': _RECORDS_PER_REQUEST
-        }
+        params = {**_GET_RECORDS_REQUEST, 'startPosition': start_record + 1}
         resp = await self.get_response(
             session, self._csw_url, params
         )

--- a/xcube_cmems/cmems.py
+++ b/xcube_cmems/cmems.py
@@ -126,14 +126,15 @@ class Cmems:
                 break
         return None
 
-    async def read_data_ids_from_csw_records(self, rec, session):
+    async def read_data_ids_from_csw_records(self, start_record: int,
+                                             session: aiohttp.ClientSession):
         params = {
             'service': 'CSW',
             'request': 'GetRecords',
             'version': '2.0.2',
             'resultType': 'results',
             'ElementSetName': 'full',
-            'startPosition': rec + 1,
+            'startPosition': start_record + 1,
             'maxRecords': RECORDS_PER_REQUEST
         }
         resp = await self.get_response(
@@ -163,9 +164,9 @@ class Cmems:
         async with aiohttp.ClientSession(
                 connector=aiohttp.TCPConnector(limit=50, force_close=True)
         ) as session:
-            for rec in range(0, TOTAL_NUM_OF_RECORDS, RECORDS_PER_REQUEST):
+            for record in range(0, TOTAL_NUM_OF_RECORDS, RECORDS_PER_REQUEST):
                 tasks.append(self.read_data_ids_from_csw_records(
-                    rec, session
+                    record, session
                 ))
             await asyncio.gather(*tasks)
 

--- a/xcube_cmems/cmems.py
+++ b/xcube_cmems/cmems.py
@@ -42,9 +42,9 @@ CSW_NAMESPACES = {
     'dc': 'http://purl.org/dc/elements/1.1/',
     'csw': 'http://www.opengis.net/cat/csw/2.0.2'
 }
-RECORDS_PER_REQUEST = 25
+_RECORDS_PER_REQUEST = 25
 # Ideally, we would read this from cmems
-TOTAL_NUM_OF_RECORDS = 300
+_TOTAL_NUM_OF_RECORDS = 300
 
 
 class Cmems:
@@ -135,7 +135,7 @@ class Cmems:
             'resultType': 'results',
             'ElementSetName': 'full',
             'startPosition': start_record + 1,
-            'maxRecords': RECORDS_PER_REQUEST
+            'maxRecords': _RECORDS_PER_REQUEST
         }
         resp = await self.get_response(
             session, self._csw_url, params
@@ -164,7 +164,7 @@ class Cmems:
         async with aiohttp.ClientSession(
                 connector=aiohttp.TCPConnector(limit=50, force_close=True)
         ) as session:
-            for record in range(0, TOTAL_NUM_OF_RECORDS, RECORDS_PER_REQUEST):
+            for record in range(0, _TOTAL_NUM_OF_RECORDS, _RECORDS_PER_REQUEST):
                 tasks.append(self.read_data_ids_from_csw_records(
                     record, session
                 ))

--- a/xcube_cmems/cmems.py
+++ b/xcube_cmems/cmems.py
@@ -43,6 +43,7 @@ CSW_NAMESPACES = {
     'csw': 'http://www.opengis.net/cat/csw/2.0.2'
 }
 
+
 class Cmems:
     """
         Represents the CMEMS opendap API

--- a/xcube_cmems/constants.py
+++ b/xcube_cmems/constants.py
@@ -26,5 +26,3 @@ CSW_URL = "https://cmems-catalog-ro.cls.fr/geonetwork/srv/eng/csw-MYOCEAN" \
           "-CORE-PRODUCTS?"
 DATA_STORE_ID = 'cmems'
 DATASET_OPENER_ID = f'dataset:zarr:{DATA_STORE_ID}'
-TOTAL_RECORDS_CSW = 300
-STEP_SIZE = 50


### PR DESCRIPTION
This is the next attempt to increase the performance of the dataset_names function.
As I found that the bottleneck are the calls to the post request in the csw library, I changed it so that we are now calling the csw url directly and not use the csw library here at all. This allows us to make parallel calls and we get another performance gain. 
I still think that it takes too long and that improvements may be possible.