### PR TITLE
diable metadata cache for backend api calls

### DIFF
--- a/xcube_cmems/cmems.py
+++ b/xcube_cmems/cmems.py
@@ -56,7 +56,7 @@ class Cmems:
 
     @classmethod
     def get_datasets_with_titles(cls) -> List[dict]:
-        catalogue: dict = cm.describe(include_datasets=True)
+        catalogue: dict = cm.describe(include_datasets=True, no_metadata_cache=True)
         datasets_info: List[dict] = []
         for product in catalogue["products"]:
             product_title = product["title"]
@@ -72,6 +72,7 @@ class Cmems:
                 dataset_id=dataset_id,
                 username=self.cmems_username,
                 password=self.cmems_password,
+                no_metadata_cache=True,
                 **open_params,
             )
             return ds


### PR DESCRIPTION
describe and open_dataset methods implemented in copernicusmarine backend writes a metadata cache by default. This feature is useful in local environments, but in cloud based environments like DeepESDL this induces error because of file permissions not being granted. This can be avoided by disabling the metadata cache 
Solves the issue https://github.com/xcube-dev/xcube-cmems/issues/36