### PR TITLE
Toniof xxx support copernicusmarine v2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 - Updated `pyproject.toml` file; package name changed from `xcube-cmems`
   to `xcube_cmems` and entry point removed, since xcube plugins 
   auto-recognition is updated. (#39 and xcube-dev/xcube#963)
+- Support use of copernicusmarine with version 2.0 and higher
 
 ## Changes in 0.1.5
 

--- a/xcube_cmems/cmems.py
+++ b/xcube_cmems/cmems.py
@@ -72,7 +72,6 @@ class Cmems:
                 dataset_id=dataset_id,
                 username=self.cmems_username,
                 password=self.cmems_password,
-                no_metadata_cache=True,
                 **open_params,
             )
             return ds


### PR DESCRIPTION
I removed a parameter which is no longer supported by copernicusmarine >= 2.0 (see here: https://toolbox-docs.marine.copernicus.eu/en/v2.0.1/changelog/v2.html# )