### PR TITLE
fix and update cmems store

### DIFF
--- a/.github/workflows/unitest-workflow.yml
+++ b/.github/workflows/unitest-workflow.yml
@@ -40,4 +40,9 @@ jobs:
           shell: bash -l {0}
           run: |
               pytest --cov=xcube_cmems --cov-report=xml
-          
+
+      -  uses: codecov/codecov-action@v4
+         with:
+             verbose: true # optional (default = false)
+
+

--- a/.github/workflows/unitest-workflow.yml
+++ b/.github/workflows/unitest-workflow.yml
@@ -15,19 +15,29 @@ jobs:
       NUMBA_DISABLE_JIT: 1
     steps:
       - name: checkout xcube-cmems
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up MicroMamba
-        uses: mamba-org/provision-with-micromamba@main
+      - name: Set up Micromamba
+        uses: mamba-org/setup-micromamba@v2
         with:
-          cache-env: true
-          extra-specs: |
-            python=3.10
+            micromamba-version: '1.4.8-0'
+            environment-file: environment.yml
+            init-shell: >-
+                bash
+            # Don't cache the environment, since this would prevent us from
+            # catching test failures caused by updated versions of dependencies.
+            cache-environment: false
+            post-cleanup: 'all'
 
-      - name: Run unit tests
-        shell: bash -l {0}
-        run: |
-          cd /home/runner/work/xcube-cmems/xcube-cmems
-          ls
-          pytest 
+      -   name: setup-xcube-cmems
+          shell: bash -l {0}
+          run: |
+              conda info
+              conda list
+              pip install -e .
+
+      -   name: unittest-xcube
+          shell: bash -l {0}
+          run: |
+              pytest --cov=xcube_cmems --cov-report=xml
           

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,17 @@
   to `xcube_cmems` and entry point removed, since xcube plugins 
   auto-recognition is updated. (#39 and xcube-dev/xcube#963)
 
+- Support boolean-valued include_attrs in get_data_ids in accordance with API update in 
+  xcube 1.8.0.
+
+- Refactored `get_datasets_with_titles()` to align with the updated return type of 
+ `cm.describe()`. (now returning a `CopernicusMarineCatalogue` object). The function 
+  now accesses products and datasets via object attributes instead of dictionary keys.
+
+- Updated dependency versions to ensure compatibility with `copernicusmarine` >= 2.1.1.
+
+- Updated GitHub Actions workflow to use the latest Micromamba setup and Python 3.12.
+
 ## Changes in 0.1.5
 
 - Disabled metadata cache to make it more suitable for cloud based environments. (#36)

--- a/environment.yml
+++ b/environment.yml
@@ -2,18 +2,20 @@ name: xcube-cmems
 channels:
   - conda-forge
 dependencies:
+  # Python
+  - python >=3.10
   # Required
   - copernicusmarine >=2.1.1
   - xcube >=1.9.1
-  - numpy <2.0.0 # xarray<2024.7.0 with numpy>=2.0.0 leads to inconsistent results
-  - xarray >=2024.7.0
+  - numpy <2.0.0 # to avoid inconsistent results with copernicusmarine package
+  - xarray >=2024.7.0 # to avoid inconsistent results with copernicusmarine package
   - pandas
   # for testing
   - black
   - flake8
   - mock
   - pytest
-
+  - pytest-cov
 
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,16 +3,15 @@ channels:
   - conda-forge
 dependencies:
   # Required
-  - copernicusmarine >=1.0.10
-  - numpy
+  - copernicusmarine >=2.1.1
+  - xcube >=1.9.1
+  - numpy <2.0.0 # xarray<2024.7.0 with numpy>=2.0.0 leads to inconsistent results
+  - xarray >=2024.7.0
   - pandas
-  - xarray
-  - xcube>=1.5.1
   # for testing
   - black
   - flake8
   - mock
-  - pathlib
   - pytest
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,10 +21,10 @@ license = {text = "MIT"}
 requires-python = ">=3.10"
 dependencies = [
     # Todo: add xcube-core when issue with matplotlib-base is solved
-    "copernicusmarine",
-    "numpy",
+    "copernicusmarine>=2.1.1",
+    "numpy<2.0.0",
+    "xarray>=2024.7.0",
     "pandas",
-    "xarray",
     "zarr"
 ]
 
@@ -41,22 +41,16 @@ exclude = [
 
 [project.optional-dependencies]
 dev = [
-  "pytest",
-  "pytest-cov",
-  "black",
-  "flake8",
-  "flake8-bugbear",
-    "pathlib"
-]
-doc = [
-  "mkdocs",
-  "mkdocs-material",
-  "mkdocstrings",
-  "mkdocstrings-python"
+      "pytest",
+      "pytest-cov",
+      "black",
+      "flake8",
+      "flake8-bugbear",
+      "pathlib"
 ]
 
 [project.urls]
 Documentation = "https://dcs4cop.github.io/xcube-cmems/"
-Issues = "hhttps://github.com/dcs4cop/xcube-cmems/issues"
+Issues = "https://github.com/dcs4cop/xcube-cmems/issues"
 Changelog = "https://github.com/dcs4cop/xcube-cmems/blob/main/CHANGES.md"
 Repository = "https://github.com/dcs4cop/xcube-cmems"

--- a/test/test_cmems.py
+++ b/test/test_cmems.py
@@ -35,30 +35,29 @@ class CmemsTest(unittest.TestCase):
 
     @patch("xcube_cmems.cmems.cm.describe")
     def test_get_datasets_with_titles(self, mock_describe):
-        # Mock the response from cm.describe
-        mock_describe.return_value = {
-            "products": [
-                {
-                    "title": "Product A",
-                    "datasets": [
-                        {"dataset_id": "dataset1"},
-                        {"dataset_id": "dataset2"},
-                    ],
-                },
-                {"title": "Product B", "datasets": [{"dataset_id": "dataset3"}]},
-            ]
-        }
+        # Create mock datasets
+        mock_dataset1 = MagicMock(dataset_id="dataset1", title="Dataset 1")
+        mock_dataset2 = MagicMock(dataset_id="dataset2", title="Dataset 2")
+        mock_dataset3 = MagicMock(dataset_id="dataset3", title="Dataset 3")
+
+        # Create mock products
+        mock_product_a = MagicMock(title="Product A", datasets=[mock_dataset1, mock_dataset2])
+        mock_product_b = MagicMock(title="Product B", datasets=[mock_dataset3])
+
+        # Mock the return value of cm.describe()
+        mock_catalogue = MagicMock()
+        mock_catalogue.products = [mock_product_a, mock_product_b]
+        mock_describe.return_value = mock_catalogue
+
         cmems = Cmems()
         datasets_info = cmems.get_datasets_with_titles()
 
-        # Expected result based on the mocked describe response
-        expected_result = [
-            {"title": "Product A", "dataset_id": "dataset1"},
-            {"title": "Product A", "dataset_id": "dataset2"},
-            {"title": "Product B", "dataset_id": "dataset3"},
+        expected = [
+            {"dataset_id": "dataset1", "title": "Product A - Dataset 1"},
+            {"dataset_id": "dataset2", "title": "Product A - Dataset 2"},
+            {"dataset_id": "dataset3", "title": "Product B - Dataset 3"},
         ]
-
-        self.assertEqual(datasets_info, expected_result)
+        self.assertEqual(datasets_info, expected)
 
     @patch("xcube_cmems.cmems.cm.open_dataset")
     def test_open_dataset(self, mock_open_dataset):

--- a/test/test_cmems.py
+++ b/test/test_cmems.py
@@ -18,9 +18,10 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-import pathlib
+
 import os
 import unittest
+from types import SimpleNamespace
 
 from xcube_cmems.cmems import Cmems
 from unittest.mock import patch, MagicMock
@@ -35,18 +36,17 @@ class CmemsTest(unittest.TestCase):
 
     @patch("xcube_cmems.cmems.cm.describe")
     def test_get_datasets_with_titles(self, mock_describe):
-        # Create mock datasets
-        mock_dataset1 = MagicMock(dataset_id="dataset1", title="Dataset 1")
-        mock_dataset2 = MagicMock(dataset_id="dataset2", title="Dataset 2")
-        mock_dataset3 = MagicMock(dataset_id="dataset3", title="Dataset 3")
+        # Fake datasets
+        dataset1 = SimpleNamespace(dataset_id="dataset1", dataset_name="Dataset 1")
+        dataset2 = SimpleNamespace(dataset_id="dataset2", dataset_name="Dataset 2")
+        dataset3 = SimpleNamespace(dataset_id="dataset3", dataset_name="Dataset 3")
 
-        # Create mock products
-        mock_product_a = MagicMock(title="Product A", datasets=[mock_dataset1, mock_dataset2])
-        mock_product_b = MagicMock(title="Product B", datasets=[mock_dataset3])
+        # Fake products
+        product_a = SimpleNamespace(title="Product A", datasets=[dataset1, dataset2])
+        product_b = SimpleNamespace(title="Product B", datasets=[dataset3])
 
-        # Mock the return value of cm.describe()
-        mock_catalogue = MagicMock()
-        mock_catalogue.products = [mock_product_a, mock_product_b]
+        # Fake catalogue
+        mock_catalogue = SimpleNamespace(products=[product_a, product_b])
         mock_describe.return_value = mock_catalogue
 
         cmems = Cmems()

--- a/xcube_cmems/cmems.py
+++ b/xcube_cmems/cmems.py
@@ -56,13 +56,15 @@ class Cmems:
 
     @classmethod
     def get_datasets_with_titles(cls) -> List[dict]:
-        catalogue: dict = cm.describe(include_datasets=True, no_metadata_cache=True)
+        catalogue: dict = cm.describe()
         datasets_info: List[dict] = []
-        for product in catalogue["products"]:
-            product_title = product["title"]
-            for dataset in product["datasets"]:
-                dataset_id: str = dataset["dataset_id"]
-                datasets_info.append({"title": product_title, "dataset_id": dataset_id})
+        for product in catalogue.products:
+            product_title = product.title
+            for dataset in product.datasets:
+                datasets_info.append({
+                    "dataset_id": dataset.dataset_id,
+                    "title": f"{product_title} - {dataset.dataset_name}"
+                })
         return datasets_info
 
     def open_dataset(self, dataset_id, **open_params) -> xr.Dataset:
@@ -72,7 +74,6 @@ class Cmems:
                 dataset_id=dataset_id,
                 username=self.cmems_username,
                 password=self.cmems_password,
-                no_metadata_cache=True,
                 **open_params,
             )
             return ds


### PR DESCRIPTION
- Support boolean-valued include_attrs in get_data_ids in accordance with API update in 
  xcube 1.8.0.

- Refactored `get_datasets_with_titles()` to align with the updated return type of 
 `cm.describe()`. (now returning a `CopernicusMarineCatalogue` object). The function 
  now accesses products and datasets via object attributes instead of dictionary keys.

- Updated dependency versions to ensure compatibility with `copernicusmarine` >= 2.1.1.

- Updated GitHub Actions workflow to use the latest Micromamba setup and Python 3.12.